### PR TITLE
Fix Mermaid lexical error in 16-id-schema.md

### DIFF
--- a/generated/llms-schema-spec.txt
+++ b/generated/llms-schema-spec.txt
@@ -9711,9 +9711,9 @@ The ID schema solves this by defining a **structured, human-readable identifier 
 
 ```mermaid
 flowchart LR
-    A[Namespace] --> B[/]
+    A[Namespace] --> B["/"]
     B --> C[Resource Type]
-    C --> D[/]
+    C --> D["/"]
     D --> E[Name]
     E --> F["coingecko/tool/simplePrice"]
 ```

--- a/generated/llms.txt
+++ b/generated/llms.txt
@@ -9711,9 +9711,9 @@ The ID schema solves this by defining a **structured, human-readable identifier 
 
 ```mermaid
 flowchart LR
-    A[Namespace] --> B[/]
+    A[Namespace] --> B["/"]
     B --> C[Resource Type]
-    C --> D[/]
+    C --> D["/"]
     D --> E[Name]
     E --> F["coingecko/tool/simplePrice"]
 ```

--- a/spec/v4.2.0/16-id-schema.md
+++ b/spec/v4.2.0/16-id-schema.md
@@ -16,9 +16,9 @@ The ID schema solves this by defining a **structured, human-readable identifier 
 
 ```mermaid
 flowchart LR
-    A[Namespace] --> B[/]
+    A[Namespace] --> B["/"]
     B --> C[Resource Type]
-    C --> D[/]
+    C --> D["/"]
     D --> E[Name]
     E --> F["coingecko/tool/simplePrice"]
 ```


### PR DESCRIPTION
Closes #64. Quote the `/` delimiter nodes (`B["/"]`, `D["/"]`) so Mermaid no longer parses `[/` as parallelogram syntax. Verified: regenerate + sync + `astro build` → no Lexical error; diagram renders as inline SVG. Unblocks docs Playwright e2e (red since before Memo 087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)