### PR TITLE
gradingSpec 3.0.2: det-grading corrections + falsifiable index.schema #81

### DIFF
--- a/grading/3.0.0/06-determinism-and-tier.md
+++ b/grading/3.0.0/06-determinism-and-tier.md
@@ -93,8 +93,8 @@ Beyond the working-test count, the data-pretest records the **size** of each wor
 
 **Binding rules:**
 
-1. `large` / `extreme` are **threshold-booleans** derived deterministically from `responseBytes`; they are grade-effective signals on the `single-test` Area. (MUST)
-2. The raw measurements (`responseBytes`, `recordCount`, `durationMs`) are recorded as metadata and are **not** themselves a pass/fail gate; only the threshold-booleans are grade-effective. (MUST)
+1. `large` / `extreme` are **threshold-booleans** derived deterministically from `responseBytes`. `extreme` is **grade-effective**: an extreme response adds a deterministic fail on the `single-test` Area that downgrades the tool (content-bloat penalty). `large` is a **recorded warning flag** — surfaced, never silently dropped, but not an automatic fail (a within-threshold response adds no size grading, so it never dilutes the working-test bar). (MUST)
+2. The raw measurements (`responseBytes`, `recordCount`, `durationMs`) are recorded as metadata and are **not** themselves a pass/fail gate. (MUST)
 3. Thresholds are fixed at **1 MB** (`large`) and **10 MB** (`extreme`). A change is a `gradingSpec` bump. (MUST)
 
 > **Rationale.** An extreme payload signals a tool that returns un-paginated bulk data — a deterministic, reproducible quality signal independent of any LLM judgement. The byte thresholds are stable across runs because they are computed from the recorded response, not re-fetched.

--- a/grading/3.0.0/CHANGELOG.md
+++ b/grading/3.0.0/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog gradingSpec
 
+## 3.0.2 — 2026-06-04 (corrections + additive)
+
+Internal-consistency corrections to the deterministic grading model, plus two additive
+deterministic dimensions. Non-breaking for any artefact that was already valid (the schema
+`required`/type fixes only *accept* artefacts the engine actually produces and *reject*
+sweep-only blobs that were never conformant).
+
+| File | Change |
+|------|--------|
+| `06-determinism-and-tier.md` | New binding rule 5: **parameterless tools reach the pass bar at 1** (parameterised stay at 2, SHOULD 3). Test-Leiter rung-1 + rule-3 carve-out for parameterless. |
+| `04-phases-single.md` | Description-cascade step 1 no longer sets a divergent "3 MUST"; it references the ch06 pass bar (2 / parameterless 1, SHOULD 3). Resolves the 3-vs-2 contradiction. |
+| `06-determinism-and-tier.md` | New **deterministic response-size dimension**: `responseBytes`/`recordCount`/`durationMs` (metadata) and threshold-booleans `large` (> 1 MB) / `extreme` (> 10 MB, grade-effective on `single-test`). |
+| `19-folder-layout.md` | New normative **addressing grammar** (`<ns>` · `<ns>/<schema>` · `<ns>/tool/<name>` · `<ns>/tool/<name>/tests/<N>`) mapped 1:1 to the layout; new **sweep-only-is-non-conformant** conformance rule (machine-falsifiable). |
+| `index.schema.json` | `proofVersion` type corrected `string` → `integer` (the engine writes `1`). `required` made discriminated: `oneOf` { island `index.json` carries `indexVersion`, no `proofVersion` } / { provider-proof `grade.json` carries `proofVersion`+`generatedAt`, no `indexVersion` }. A blob with neither discriminator now fails validation (falsifiable). |
+
 ## 3.0.1 — 2026-06-04 (additive)
 
 Additive, non-breaking. The pinned `blockedReason` enum gains **`fewer-than-two-tests`** —

--- a/grading/3.0.0/index.schema.json
+++ b/grading/3.0.0/index.schema.json
@@ -36,7 +36,10 @@
                 },
                 "grade": { "type": "string" },
                 "ref": { "type": "string" },
-                "reason": { "$ref": "#/$defs/blockedReason" },
+                "reason": {
+                    "type": "string",
+                    "description": "On a blocked node the reason MUST be a closed-set blockedReason (enforced by the conditional below). On a pending/graded node it MAY carry an informational free-text reason (e.g. 'no about graded')."
+                },
                 "monitoring": { "$ref": "#/$defs/monitoring" },
                 "boundTo": { "type": "string" },
                 "snapshot": {
@@ -45,7 +48,14 @@
                 }
             },
             "required": [ "status" ],
-            "additionalProperties": true
+            "additionalProperties": true,
+            "if": {
+                "properties": { "status": { "const": "blocked" } },
+                "required": [ "status" ]
+            },
+            "then": {
+                "properties": { "reason": { "$ref": "#/$defs/blockedReason" } }
+            }
         }
     },
     "properties": {
@@ -101,7 +111,10 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "reason": { "$ref": "#/$defs/blockedReason" },
+                    "reason": {
+                        "type": "string",
+                        "description": "Diagnostic blocker reason. Mirrors the derived node-level reason, which includes pending diagnostics (e.g. 'not yet graded') as well as the closed-set blockedReason values. The closed-set guarantee is enforced on a blocked NODE's reason (see $defs/node conditional), not on this diagnostic list."
+                    },
                     "schemaFile": { "type": "string" },
                     "tool": { "type": "string" },
                     "message": { "type": "string" }


### PR DESCRIPTION
Closes #81.

Internal-consistency corrections to the deterministic grading model + a sound, falsifiable `index.schema.json` (ajv-verified: canonical accepted, sweep-only rejected). See the issue for the per-file breakdown. gradingSpec CHANGELOG → 3.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)