### PR TITLE
Grading area-dependency model + emit-skill format (Memo 110)

### DIFF
--- a/generated/llms-schema-spec.txt
+++ b/generated/llms-schema-spec.txt
@@ -10928,11 +10928,11 @@ CLI is responsible for 1 and 3. Grader is responsible for 2. Communication via J
 
 ## Delegation — the grading model lives in the Grading-Spec
 
-FlowMCP is the highest instance and **delegates the grading model** to a separate, independently versioned standard: the **Grading-Spec** (`gradingSpec/2.0.0`), published as a dedicated docs area. The Grading-Spec owns the grading model — score-to-grade thresholds, the extended dimension set, Scoring System, Grading System, Categorical-Veto, Tier-trim, and skill families.
+FlowMCP is the highest instance and **delegates the grading model** to a separate, independently versioned standard: the **Grading-Spec** (`gradingSpec/3.0.0`), published as a dedicated docs area. The Grading-Spec owns the grading model — score-to-grade thresholds, the extended dimension set, Scoring System, Grading System, Categorical-Veto, Tier-trim, and skill families.
 
 This file owns the **upstream scoring transport** only: the deterministic `prompts.json` / `scores.json` artefact pair exchanged between the CLI and an external Grader. The Grading-Spec **sub-consumes** this transport and treats it as the highest instance for the artefact pair — it does not redefine it.
 
-Entry point: [Grading-Spec 2.0.0 — Overview](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/00-overview.md).
+Entry point: [Grading-Spec 3.0.0 — Overview](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/00-overview.md).
 
 ---
 
@@ -10953,13 +10953,13 @@ Each schema is evaluated on 2 dimensions:
 | `whenToUse` | Clarity and specificity of the schema description (does an LLM know when to use this schema?) |
 | `parameters` | How well the parameter descriptions enable correct tool invocation |
 
-Each dimension yields a score on a 1.0-5.0 scale (floating point). These two are the **base transport dimensions**; the Grading-Spec ([`08-grading-model.md` §Dimension Enum](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/08-grading-model.md)) extends this set with the additional grading dimensions it owns.
+Each dimension yields a score on a 1.0-5.0 scale (floating point). These two are the **base transport dimensions**; the Grading-Spec ([`08-grading-model.md` §Dimension Enum](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/08-grading-model.md)) extends this set with the additional grading dimensions it owns.
 
 ---
 
 ## Grade Thresholds — delegated to the Grading-Spec
 
-The score-to-grade banding, the production gate, the tier-trim rule and the Categorical-Veto list are **owned by the Grading-Spec** (`gradingSystem/1.0.0`), not by this transport protocol. See [Grading-Spec 2.0.0 — §4.1 Score-to-Grade Thresholds](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/07-scoring-vs-grading.md). Changing any threshold or the numeric mapping bumps the `gradingSystem` version independently of `scoringProtocol`.
+The score-to-grade banding, the production gate, the tier-trim rule and the Categorical-Veto list are **owned by the Grading-Spec** (`gradingSystem/1.0.0`), not by this transport protocol. See [Grading-Spec 3.0.0 — §4.1 Score-to-Grade Thresholds](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/07-scoring-vs-grading.md). Changing any threshold or the numeric mapping bumps the `gradingSystem` version independently of `scoringProtocol`.
 
 ---
 

--- a/generated/llms.txt
+++ b/generated/llms.txt
@@ -10928,11 +10928,11 @@ CLI is responsible for 1 and 3. Grader is responsible for 2. Communication via J
 
 ## Delegation — the grading model lives in the Grading-Spec
 
-FlowMCP is the highest instance and **delegates the grading model** to a separate, independently versioned standard: the **Grading-Spec** (`gradingSpec/2.0.0`), published as a dedicated docs area. The Grading-Spec owns the grading model — score-to-grade thresholds, the extended dimension set, Scoring System, Grading System, Categorical-Veto, Tier-trim, and skill families.
+FlowMCP is the highest instance and **delegates the grading model** to a separate, independently versioned standard: the **Grading-Spec** (`gradingSpec/3.0.0`), published as a dedicated docs area. The Grading-Spec owns the grading model — score-to-grade thresholds, the extended dimension set, Scoring System, Grading System, Categorical-Veto, Tier-trim, and skill families.
 
 This file owns the **upstream scoring transport** only: the deterministic `prompts.json` / `scores.json` artefact pair exchanged between the CLI and an external Grader. The Grading-Spec **sub-consumes** this transport and treats it as the highest instance for the artefact pair — it does not redefine it.
 
-Entry point: [Grading-Spec 2.0.0 — Overview](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/00-overview.md).
+Entry point: [Grading-Spec 3.0.0 — Overview](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/00-overview.md).
 
 ---
 
@@ -10953,13 +10953,13 @@ Each schema is evaluated on 2 dimensions:
 | `whenToUse` | Clarity and specificity of the schema description (does an LLM know when to use this schema?) |
 | `parameters` | How well the parameter descriptions enable correct tool invocation |
 
-Each dimension yields a score on a 1.0-5.0 scale (floating point). These two are the **base transport dimensions**; the Grading-Spec ([`08-grading-model.md` §Dimension Enum](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/08-grading-model.md)) extends this set with the additional grading dimensions it owns.
+Each dimension yields a score on a 1.0-5.0 scale (floating point). These two are the **base transport dimensions**; the Grading-Spec ([`08-grading-model.md` §Dimension Enum](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/08-grading-model.md)) extends this set with the additional grading dimensions it owns.
 
 ---
 
 ## Grade Thresholds — delegated to the Grading-Spec
 
-The score-to-grade banding, the production gate, the tier-trim rule and the Categorical-Veto list are **owned by the Grading-Spec** (`gradingSystem/1.0.0`), not by this transport protocol. See [Grading-Spec 2.0.0 — §4.1 Score-to-Grade Thresholds](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/07-scoring-vs-grading.md). Changing any threshold or the numeric mapping bumps the `gradingSystem` version independently of `scoringProtocol`.
+The score-to-grade banding, the production gate, the tier-trim rule and the Categorical-Veto list are **owned by the Grading-Spec** (`gradingSystem/1.0.0`), not by this transport protocol. See [Grading-Spec 3.0.0 — §4.1 Score-to-Grade Thresholds](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/07-scoring-vs-grading.md). Changing any threshold or the numeric mapping bumps the `gradingSystem` version independently of `scoringProtocol`.
 
 ---
 

--- a/grading/3.0.0/21-pre-conditions.md
+++ b/grading/3.0.0/21-pre-conditions.md
@@ -78,6 +78,68 @@ Non-stable Members:
 Follow-up action: complete the Single-Gradings, then rebuild the index and refreeze the lockSnapshot.
 ```
 
+### Area Dependency Model (normative)
+
+The 11 Areas are graded against a **readiness ladder** and a per-Area **dependency
+gate**. The ladder is monotonic:
+
+```
+imported → structural-valid → deterministic-green → stable
+```
+
+- `structural-valid` — passes `flowmcp validate` (structure).
+- `deterministic-green` — structural-valid AND the deterministic data-pretest is ok
+  (HTTP 200 **and** non-empty data) per [`06-determinism-and-tier.md`](./06-determinism-and-tier.md).
+- `stable` — full grading promoted to stable.
+
+Each Area declares a `dependsOn` and a `requiredLevel` gate. The reference engine
+keeps this as DATA (`area-dependency-graph.json`); this table is its normative source:
+
+| Area | dependsOn | requiredLevel | dimension |
+|------|-----------|---------------|-----------|
+| `single-test` | none | `structural-valid` | both (det gate + non-det) |
+| `tools-aggregate-schema` | none | `structural-valid` | both |
+| `tools-aggregate-namespace` | all-namespace-schemas | **`deterministic-green`** | both |
+| `namespace-description` | all-namespace-schemas | **`deterministic-green`** | non-det |
+| `namespace-skills` | all-namespace-schemas | **`deterministic-green`** | non-det |
+| `about-namespace` | about-resource-present | **`stable`** | both |
+| `about-selection` | all-member-schemas | `stable` | non-det |
+| `selection-skills-L1/L2/L3` | all-member-schemas | `stable` | non-det |
+| `selection-aggregate` | all-member-schemas | `stable` | non-det |
+
+Two gates are binding:
+
+1. **Provider-Namespace-Gate** — the namespace Areas
+   (`tools-aggregate-namespace`, `namespace-description`, `namespace-skills`) are
+   held until **every** schema of the namespace is `deterministic-green`. The
+   namespace level folds onto the **weakest** schema. This is the cost guard: no
+   namespace-wide LLM round runs while any schema still fails its data-pretest.
+2. **About-Namespace-Gate** — `about-namespace` is an aggregate check and follows
+   the universal pre-condition above (`stable`), not `structural-valid`.
+
+`dimension` is the work split: `deterministic` = the CLI finishes it for free;
+`non-det` = it needs an LLM scoring round; `both` = a free deterministic gate AND
+an LLM round for the descriptive questions (`single-test` / `tools-aggregate-schema`
+carry a deterministic pretest gate plus non-deterministic description scoring).
+
+### Emit-Skill Format (normative)
+
+The non-deterministic emit (`grading non-deterministic <ns> --emit-prompts`)
+returns ONE **self-contained Emit-Skill** — a single instruction text handed to a
+sub-agent, that MUST carry, inline in the text:
+
+1. a self-describing header (this is a grading skill, work the bundled areas in one pass);
+2. the **currently-ready stage's** non-deterministic Area prompts, with the real
+   schema path, tool/namespace names and the output schema **inline** (no unresolved
+   placeholder may survive);
+3. a **Task-ID** (the emit↔consume join key);
+4. the explicit `--consume-scores` return command and the expected answer count.
+
+Hard-gated stage-2 Areas (`namespace-*`) are NOT emitted in the same skill; they are
+emitted in a **follow-up** skill once the Provider-Namespace-Gate opens. The
+transport envelope is owned by [`spec/v4.3.0/22-scoring-protocol.md`]; this section
+owns the Area composition + bundling rules.
+
 ### Cross-Refs
 
 - Tier trim — full vs. partial → [`06-determinism-and-tier.md`](./06-determinism-and-tier.md)

--- a/grading/3.0.0/CHANGELOG.md
+++ b/grading/3.0.0/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog gradingSpec
 
+## 3.0.3 — 2026-06-05 (additive — Area dependency model + Emit-Skill format)
+
+Additive, non-breaking. Promotes the Area dependency model from reference-engine DATA
+into the normative spec and pins the Emit-Skill format.
+
+| File | Change |
+|------|--------|
+| `21-pre-conditions.md` | New normative **Area Dependency Model**: the readiness ladder (`imported → structural-valid → deterministic-green → stable`), the per-Area `dependsOn`/`requiredLevel`/dimension table, and the two binding gates — the **Provider-Namespace-Gate** (`namespace-*` held until every schema is `deterministic-green`, folding onto the weakest schema) and the **About-Namespace-Gate** (`stable`, per the universal pre-condition). `single-test` / `tools-aggregate-schema` are classified **both** (deterministic gate + non-deterministic description scoring). |
+| `21-pre-conditions.md` | New normative **Emit-Skill Format**: `--emit-prompts` returns ONE self-contained skill text carrying the ready-stage Area prompts (real paths + inline output schema, no surviving placeholder), the Task-ID, and the `--consume-scores` return command; gated `namespace-*` Areas follow in a separate emit once the Provider-Namespace-Gate opens. |
+
 ## 3.0.2 — 2026-06-04 (corrections + additive)
 
 Internal-consistency corrections to the deterministic grading model, plus two additive

--- a/spec/v4.3.0/22-scoring-protocol.md
+++ b/spec/v4.3.0/22-scoring-protocol.md
@@ -25,11 +25,11 @@ CLI is responsible for 1 and 3. Grader is responsible for 2. Communication via J
 
 ## Delegation — the grading model lives in the Grading-Spec
 
-FlowMCP is the highest instance and **delegates the grading model** to a separate, independently versioned standard: the **Grading-Spec** (`gradingSpec/2.0.0`), published as a dedicated docs area. The Grading-Spec owns the grading model — score-to-grade thresholds, the extended dimension set, Scoring System, Grading System, Categorical-Veto, Tier-trim, and skill families.
+FlowMCP is the highest instance and **delegates the grading model** to a separate, independently versioned standard: the **Grading-Spec** (`gradingSpec/3.0.0`), published as a dedicated docs area. The Grading-Spec owns the grading model — score-to-grade thresholds, the extended dimension set, Scoring System, Grading System, Categorical-Veto, Tier-trim, and skill families.
 
 This file owns the **upstream scoring transport** only: the deterministic `prompts.json` / `scores.json` artefact pair exchanged between the CLI and an external Grader. The Grading-Spec **sub-consumes** this transport and treats it as the highest instance for the artefact pair — it does not redefine it.
 
-Entry point: [Grading-Spec 2.0.0 — Overview](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/00-overview.md).
+Entry point: [Grading-Spec 3.0.0 — Overview](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/00-overview.md).
 
 ---
 
@@ -50,13 +50,13 @@ Each schema is evaluated on 2 dimensions:
 | `whenToUse` | Clarity and specificity of the schema description (does an LLM know when to use this schema?) |
 | `parameters` | How well the parameter descriptions enable correct tool invocation |
 
-Each dimension yields a score on a 1.0-5.0 scale (floating point). These two are the **base transport dimensions**; the Grading-Spec ([`08-grading-model.md` §Dimension Enum](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/08-grading-model.md)) extends this set with the additional grading dimensions it owns.
+Each dimension yields a score on a 1.0-5.0 scale (floating point). These two are the **base transport dimensions**; the Grading-Spec ([`08-grading-model.md` §Dimension Enum](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/08-grading-model.md)) extends this set with the additional grading dimensions it owns.
 
 ---
 
 ## Grade Thresholds — delegated to the Grading-Spec
 
-The score-to-grade banding, the production gate, the tier-trim rule and the Categorical-Veto list are **owned by the Grading-Spec** (`gradingSystem/1.0.0`), not by this transport protocol. See [Grading-Spec 2.0.0 — §4.1 Score-to-Grade Thresholds](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/2.0.0/07-scoring-vs-grading.md). Changing any threshold or the numeric mapping bumps the `gradingSystem` version independently of `scoringProtocol`.
+The score-to-grade banding, the production gate, the tier-trim rule and the Categorical-Veto list are **owned by the Grading-Spec** (`gradingSystem/1.0.0`), not by this transport protocol. See [Grading-Spec 3.0.0 — §4.1 Score-to-Grade Thresholds](https://github.com/FlowMCP/flowmcp-spec/blob/main/grading/3.0.0/07-scoring-vs-grading.md). Changing any threshold or the numeric mapping bumps the `gradingSystem` version independently of `scoringProtocol`.
 
 ---
 


### PR DESCRIPTION
Closes #86.

- **21-pre-conditions.md** — normative Area Dependency Model (readiness ladder, per-area dependsOn/requiredLevel/dimension table, Provider-Namespace-Gate `deterministic-green` + About-Namespace-Gate `stable`) and the self-contained Emit-Skill format (Task-ID + `--consume-scores` command in the text; gated `namespace-*` follow-up).
- **grading CHANGELOG** 3.0.3.
- **spec/v4.3.0/22-scoring-protocol.md** — grading delegation raised `2.0.0` → `3.0.0` (Befund J).

🤖 Generated with [Claude Code](https://claude.com/claude-code)